### PR TITLE
feat: Add GCPINTERCONNECTINTERCONNECT entity definition

### DIFF
--- a/entity-types/infra-gcpinterconnectinterconnect/dashboard.json
+++ b/entity-types/infra-gcpinterconnectinterconnect/dashboard.json
@@ -1,0 +1,186 @@
+{
+  "name": "GCP Interconnect",
+  "description": null,
+  "pages": [
+    {
+      "name": "GCP Interconnect",
+      "description": null,
+      "widgets": [
+        {
+          "title": "Ingress Bytes",
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT sum(`gcp.interconnect.network.interconnect.received_bytes_count`) AS 'Ingress Bytes' WHERE `entity.guid` = '{{entity.guid}}' TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Egress Bytes",
+          "layout": {
+            "column": 5,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT sum(`gcp.interconnect.network.interconnect.sent_bytes_count`) AS 'Egress Bytes' WHERE `entity.guid` = '{{entity.guid}}' TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Dropped Packets",
+          "layout": {
+            "column": 9,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT sum(`gcp.interconnect.network.interconnect.dropped_packets_count`) AS 'Dropped Packets' WHERE `entity.guid` = '{{entity.guid}}' TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Network Capacity",
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT max(`gcp.interconnect.network.interconnect.capacity`) AS 'Capacity (By/s)' WHERE `entity.guid` = '{{entity.guid}}' TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Ingress / Egress Errors",
+          "layout": {
+            "column": 5,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT sum(`gcp.interconnect.network.interconnect.receive_errors_count`) AS 'Ingress Errors', sum(`gcp.interconnect.network.interconnect.send_errors_count`) AS 'Egress Errors' WHERE `entity.guid` = '{{entity.guid}}' TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Operational Status",
+          "layout": {
+            "column": 9,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "FROM Metric SELECT latest(`gcp.interconnect.network.interconnect.operational`) AS 'Operational (1=up)' WHERE `entity.guid` = '{{entity.guid}}' TIMESERIES AUTO"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-gcpinterconnectinterconnect/definition.yml
+++ b/entity-types/infra-gcpinterconnectinterconnect/definition.yml
@@ -1,5 +1,8 @@
 domain: INFRA
 type: GCPINTERCONNECTINTERCONNECT
+goldenTags:
+- gcp.projectId
+- gcp.region
 configuration:
   entityExpirationTime: DAILY
   alertable: true

--- a/entity-types/infra-gcpinterconnectinterconnect/golden_metrics.yml
+++ b/entity-types/infra-gcpinterconnectinterconnect/golden_metrics.yml
@@ -1,0 +1,27 @@
+ingressBytes:
+  title: Ingress Bytes
+  unit: BYTES
+  queries:
+    gcp:
+      select: sum(`gcp.interconnect.network.interconnect.received_bytes_count`)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+egressBytes:
+  title: Egress Bytes
+  unit: BYTES
+  queries:
+    gcp:
+      select: sum(`gcp.interconnect.network.interconnect.sent_bytes_count`)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+droppedPackets:
+  title: Dropped Packets
+  unit: COUNT
+  queries:
+    gcp:
+      select: sum(`gcp.interconnect.network.interconnect.dropped_packets_count`)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name

--- a/entity-types/infra-gcpinterconnectinterconnect/summary_metrics.yml
+++ b/entity-types/infra-gcpinterconnectinterconnect/summary_metrics.yml
@@ -1,0 +1,22 @@
+providerAccountName:
+  tag:
+    key: providerAccountName
+  title: GCP account
+  unit: STRING
+gcpProjectId:
+  tag:
+    key: gcp.projectId
+  title: GCP Project ID
+  unit: STRING
+ingressBytes:
+  goldenMetric: ingressBytes
+  unit: BYTES
+  title: Ingress Bytes
+egressBytes:
+  goldenMetric: egressBytes
+  unit: BYTES
+  title: Egress Bytes
+droppedPackets:
+  goldenMetric: droppedPackets
+  unit: COUNT
+  title: Dropped Packets


### PR DESCRIPTION
🛡️ **SAFE MODE** - This PR is within your fork only.

### Relevant information

Adding GCPINTERCONNECTINTERCONNECT entity definition for GCP Cloud Interconnect (physical circuit).

This PR adds:
- definition.yml with goldenTags (gcp.projectId, gcp.region) and alertable: true
- golden_metrics.yml with ingressBytes, egressBytes, droppedPackets
- summary_metrics.yml with providerAccountName, gcp.projectId, and 3 golden metric refs
- dashboard.json with 6 widgets

### Checklist

* [x] I have read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid.
* [x] I have confirmed that my entity type was not already fully defined.