### PR TITLE
feat: refresh GCP BigQuery Project entity (Metric + dashboard)

### DIFF
--- a/entity-types/infra-gcpbigqueryproject/dashboard.json
+++ b/entity-types/infra-gcpbigqueryproject/dashboard.json
@@ -1,0 +1,219 @@
+{
+  "name": "GCP BigQuery Project",
+  "pages": [
+    {
+      "name": "GCP BigQuery Project",
+      "widgets": [
+        {
+          "visualization": {
+            "id": "viz.billboard"
+          },
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "height": 3,
+            "width": 4
+          },
+          "title": "In flight queries",
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "query": "FROM Metric SELECT latest(`gcp.bigquery.query.in_flight`) AS 'In flight' WHERE entity.guid = '{{entity.id}}' SINCE 1 hour ago",
+                "accountId": 0}
+            ]
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.billboard"
+          },
+          "layout": {
+            "column": 5,
+            "row": 1,
+            "height": 3,
+            "width": 4
+          },
+          "title": "In flight jobs",
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "query": "FROM Metric SELECT latest(`gcp.bigquery.job.num_in_flight`) AS 'In flight' WHERE entity.guid = '{{entity.id}}' SINCE 1 hour ago",
+                "accountId": 0}
+            ]
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.billboard"
+          },
+          "layout": {
+            "column": 9,
+            "row": 1,
+            "height": 3,
+            "width": 4
+          },
+          "title": "Slots allocated",
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "query": "FROM Metric SELECT latest(`gcp.bigquery.slots.allocated_for_project`) AS 'Slots' WHERE entity.guid = '{{entity.id}}' SINCE 1 hour ago",
+                "accountId": 0}
+            ]
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "height": 3,
+            "width": 6
+          },
+          "title": "Queries executed",
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "query": "FROM Metric SELECT sum(`gcp.bigquery.query.count`) AS 'Queries' WHERE entity.guid = '{{entity.id}}' TIMESERIES AUTO",
+                "accountId": 0}
+            ]
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 7,
+            "row": 4,
+            "height": 3,
+            "width": 6
+          },
+          "title": "Query execution time (s)",
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "query": "FROM Metric SELECT average(`gcp.bigquery.query.execution_times`) AS 'Avg', max(`gcp.bigquery.query.execution_times`) AS 'Max' WHERE entity.guid = '{{entity.id}}' TIMESERIES AUTO",
+                "accountId": 0}
+            ]
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 1,
+            "row": 7,
+            "height": 3,
+            "width": 6
+          },
+          "title": "Query scanned bytes by statement type",
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "query": "FROM Metric SELECT sum(`gcp.bigquery.query.scanned_bytes`) AS 'Scanned' WHERE entity.guid = '{{entity.id}}' FACET `metric.statement_type` TIMESERIES AUTO",
+                "accountId": 0}
+            ]
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 7,
+            "row": 7,
+            "height": 3,
+            "width": 6
+          },
+          "title": "Query scanned bytes billed",
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "query": "FROM Metric SELECT sum(`gcp.bigquery.query.scanned_bytes_billed`) AS 'Billed' WHERE entity.guid = '{{entity.id}}' TIMESERIES AUTO",
+                "accountId": 0}
+            ]
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 1,
+            "row": 10,
+            "height": 3,
+            "width": 6
+          },
+          "title": "Slots allocated by job type",
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "query": "FROM Metric SELECT average(`gcp.bigquery.slots.allocated_for_project`) AS 'Slots' WHERE entity.guid = '{{entity.id}}' FACET `metric.job_type` TIMESERIES AUTO",
+                "accountId": 0}
+            ]
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 7,
+            "row": 10,
+            "height": 3,
+            "width": 6
+          },
+          "title": "Slots assigned by job type",
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "query": "FROM Metric SELECT average(`gcp.bigquery.slots.assigned`) AS 'Slots' WHERE entity.guid = '{{entity.id}}' FACET `metric.job_type` TIMESERIES AUTO",
+                "accountId": 0}
+            ]
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 1,
+            "row": 13,
+            "height": 3,
+            "width": 6
+          },
+          "title": "Streaming inserts — bytes",
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "query": "FROM Metric SELECT sum(`gcp.bigquery.storage.insertall_inserted_bytes`) AS 'Bytes' WHERE entity.guid = '{{entity.id}}' TIMESERIES AUTO",
+                "accountId": 0}
+            ]
+          }
+        },
+        {
+          "visualization": {
+            "id": "viz.line"
+          },
+          "layout": {
+            "column": 7,
+            "row": 13,
+            "height": 3,
+            "width": 6
+          },
+          "title": "Streaming inserts — rows",
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "query": "FROM Metric SELECT sum(`gcp.bigquery.storage.insertall_inserted_rows`) AS 'Rows' WHERE entity.guid = '{{entity.id}}' TIMESERIES AUTO",
+                "accountId": 0}
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-gcpbigqueryproject/definition.yml
+++ b/entity-types/infra-gcpbigqueryproject/definition.yml
@@ -4,6 +4,10 @@ configuration:
   entityExpirationTime: DAILY
   alertable: true
 
+goldenTags:
+  - gcp.projectId
+  - gcp.region
+
 ownership:
   primaryOwner:
     teamName: "Cloud Monitoring Platform"

--- a/entity-types/infra-gcpbigqueryproject/golden_metrics.yml
+++ b/entity-types/infra-gcpbigqueryproject/golden_metrics.yml
@@ -1,14 +1,46 @@
 queries:
-  query:
-    eventId: entityGuid
-    select: sum(`query.Count`)
-    from: GcpBigQueryProjectSample
-  unit: COUNT
   title: Queries
+  unit: COUNT
+  queries:
+    gcp:
+      select: sum(`gcp.bigquery.query.count`)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    gcpSample:
+      select: sum(`query.Count`)
+      from: GcpBigQueryProjectSample
+      eventId: entityGuid
+      eventName: entityName
 executionTime:
-  query:
-    eventId: entityGuid
-    select: average(`query.ExecutionTimes`)
-    from: GcpBigQueryProjectSample
-  unit: SECONDS
   title: Execution time
+  unit: SECONDS
+  queries:
+    gcp:
+      select: average(`gcp.bigquery.query.execution_times`)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+    gcpSample:
+      select: average(`query.ExecutionTimes`)
+      from: GcpBigQueryProjectSample
+      eventId: entityGuid
+      eventName: entityName
+queryScannedBytes:
+  title: Query scanned bytes
+  unit: BYTES
+  queries:
+    gcp:
+      select: sum(`gcp.bigquery.query.scanned_bytes`)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+slotsAllocated:
+  title: Slots allocated
+  unit: COUNT
+  queries:
+    gcp:
+      select: average(`gcp.bigquery.slots.allocated_for_project`)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name

--- a/entity-types/infra-gcpbigqueryproject/summary_metrics.yml
+++ b/entity-types/infra-gcpbigqueryproject/summary_metrics.yml
@@ -3,6 +3,11 @@ providerAccountName:
     key: providerAccountName
   title: GCP account
   unit: STRING
+gcpProjectId:
+  tag:
+    key: gcp.projectId
+  title: GCP Project ID
+  unit: STRING
 queries:
   goldenMetric: queries
   unit: COUNT
@@ -11,3 +16,11 @@ executionTime:
   goldenMetric: executionTime
   unit: SECONDS
   title: Execution time
+queryScannedBytes:
+  goldenMetric: queryScannedBytes
+  unit: BYTES
+  title: Query Scanned Bytes
+slotsAllocated:
+  goldenMetric: slotsAllocated
+  unit: COUNT
+  title: Slots Allocated


### PR DESCRIPTION
## Summary

Refreshes the GCP BigQuery Project entity definition with modern Metric-based queries and adds a proper dashboard.

- Add \`gcp.projectId\` and \`gcp.region\` goldenTags
- Preserve existing Sample-based golden metrics (\`queries\`, \`executionTime\`) and add \`gcp:\` (Metric event) equivalents alongside them
- Add two new golden metrics: \`queryScannedBytes\`, \`slotsAllocated\`
- Update \`summary_metrics.yml\` to reference the new golden metrics and expose the \`gcp.projectId\` tag
- Add \`dashboard.json\` with 11 widgets (billboards + timeseries) using \`FROM Metric\`

Fresh regeneration replacing prior work in closed PR #2987.

## Test plan
- [ ] \`npm --prefix validator run validate-schemas\` passes locally
- [ ] Sanitize dashboards makes no changes
- [ ] Verify metrics resolve in NR account after merge (deferred — NR MCP was not available at generation time)

🤖 Generated with [Claude Code](https://claude.com/claude-code)