### PR TITLE
feat: Add GCPCOMPOSERWORKLOAD entity definition

### DIFF
--- a/entity-types/infra-gcpcomposerworkload/dashboard.json
+++ b/entity-types/infra-gcpcomposerworkload/dashboard.json
@@ -1,0 +1,331 @@
+{
+  "name": "GCP Cloud Composer Workload",
+  "description": null,
+  "pages": [
+    {
+      "name": "Summary",
+      "description": null,
+      "widgets": [
+        {
+          "title": "CPU Usage Time",
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.composer.workload.cpu.usage_time`) FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "CPU Reserved Cores",
+          "layout": {
+            "column": 5,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT latest(`gcp.composer.workload.cpu.reserved_cores`) FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Memory Usage",
+          "layout": {
+            "column": 9,
+            "row": 1,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT average(`gcp.composer.workload.memory.bytes_used`) FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Memory Quota",
+          "layout": {
+            "column": 1,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT latest(`gcp.composer.workload.memory.quota`) FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Disk Usage",
+          "layout": {
+            "column": 5,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT latest(`gcp.composer.workload.disk.bytes_used`) FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Disk Quota",
+          "layout": {
+            "column": 9,
+            "row": 4,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT latest(`gcp.composer.workload.disk.quota`) FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Restart Count",
+          "layout": {
+            "column": 1,
+            "row": 7,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.composer.workload.restart_count`) FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Log Entries",
+          "layout": {
+            "column": 5,
+            "row": 7,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT sum(`gcp.composer.workload.log_entry_count`) FROM Metric WHERE entity.guid = '{{entity.id}}' FACET `metric.severity` TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Uptime",
+          "layout": {
+            "column": 9,
+            "row": 7,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT latest(`gcp.composer.workload.uptime`) FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "DAGs Sync Duration",
+          "layout": {
+            "column": 1,
+            "row": 10,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT latest(`gcp.composer.workload.dags_sync_duration`) FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        },
+        {
+          "title": "Plugins Sync Duration",
+          "layout": {
+            "column": 5,
+            "row": 10,
+            "width": 4,
+            "height": 3
+          },
+          "visualization": {
+            "id": "viz.line"
+          },
+          "rawConfiguration": {
+            "facet": {
+              "showOtherSeries": false
+            },
+            "legend": {
+              "enabled": true
+            },
+            "nrqlQueries": [
+              {
+                "accountId": 0,
+                "query": "SELECT latest(`gcp.composer.workload.plugins_sync_duration`) FROM Metric WHERE entity.guid = '{{entity.id}}' TIMESERIES auto"
+              }
+            ],
+            "yAxisLeft": {
+              "zero": true
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/entity-types/infra-gcpcomposerworkload/definition.yml
+++ b/entity-types/infra-gcpcomposerworkload/definition.yml
@@ -1,0 +1,11 @@
+domain: INFRA
+type: GCPCOMPOSERWORKLOAD
+goldenTags:
+- gcp.projectId
+- gcp.region
+configuration:
+  entityExpirationTime: DAILY
+  alertable: true
+ownership:
+  primaryOwner:
+    teamName: "Cloud Monitoring Platform"

--- a/entity-types/infra-gcpcomposerworkload/golden_metrics.yml
+++ b/entity-types/infra-gcpcomposerworkload/golden_metrics.yml
@@ -1,0 +1,27 @@
+cpuUsageTime:
+  title: CPU Usage Time
+  unit: SECONDS
+  queries:
+    gcp:
+      select: sum(gcp.composer.workload.cpu.usage_time)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+memoryUsage:
+  title: Memory Usage
+  unit: BYTES
+  queries:
+    gcp:
+      select: average(gcp.composer.workload.memory.bytes_used)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name
+restartCount:
+  title: Restart Count
+  unit: COUNT
+  queries:
+    gcp:
+      select: sum(gcp.composer.workload.restart_count)
+      from: Metric
+      eventId: entity.guid
+      eventName: entity.name

--- a/entity-types/infra-gcpcomposerworkload/summary_metrics.yml
+++ b/entity-types/infra-gcpcomposerworkload/summary_metrics.yml
@@ -1,0 +1,22 @@
+providerAccountName:
+  tag:
+    key: providerAccountName
+  title: GCP account
+  unit: STRING
+gcpProjectId:
+  tag:
+    key: gcp.projectId
+  title: GCP Project ID
+  unit: STRING
+cpuUsageTime:
+  goldenMetric: cpuUsageTime
+  unit: SECONDS
+  title: CPU Usage Time
+memoryUsage:
+  goldenMetric: memoryUsage
+  unit: BYTES
+  title: Memory Usage
+restartCount:
+  goldenMetric: restartCount
+  unit: COUNT
+  title: Restart Count


### PR DESCRIPTION
🛡️ **SAFE MODE** — This PR is within the fork only, not targeting upstream.

### Relevant information

Adding `GCPCOMPOSERWORKLOAD` entity definition for GCP Cloud Composer Workload — the individual Airflow workload instances running inside a Cloud Composer environment.

This PR adds:
- `definition.yml` with alertable and DAILY expiration, goldenTags for `gcp.projectId` and `gcp.region`
- `golden_metrics.yml` with CPU usage time, memory usage, and restart count
- `summary_metrics.yml` referencing provider account name, GCP project ID, and the three golden metrics
- `dashboard.json` with widgets covering CPU, memory, disk, restarts, log entries, uptime, and DAG/plugin sync

Metric names are sourced from the [GCP Cloud Composer metrics reference](https://cloud.google.com/monitoring/api/metrics_gcp_c#gcp-composer) (BETA-launch metrics only; ALPHA `workload/trigger/num_running` was skipped).

⚠️ NR MCP metric validation (Phase 3a) was skipped this session because MCP auth had expired. Queries were validated for syntax and schema only; live-data confirmation has not been done.

### Checklist

* [x] I've read the guidelines and understand the acceptance criteria.
* [x] The value of the attribute marked as `identifier` will be unique and valid.
* [x] I've confirmed that my entity type wasn't already defined.